### PR TITLE
feat: add metadata editing & artwork support

### DIFF
--- a/index.html
+++ b/index.html
@@ -596,6 +596,74 @@
             border-color: var(--accent-orange);
         }
 
+        .form-group select {
+            width: 100%;
+            padding: 10px 14px;
+            background: rgba(0, 0, 0, 0.3);
+            border: 1px solid var(--glass-border);
+            border-radius: 6px;
+            color: var(--text-dark);
+            font-family: inherit;
+            font-size: 13px;
+            cursor: pointer;
+        }
+
+        .form-group select:focus {
+            outline: none;
+            border-color: var(--accent-orange);
+        }
+
+        .form-group select option {
+            background: #1a1a2e;
+            color: var(--text-dark);
+        }
+
+        .edit-metadata-grid {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            column-gap: 16px;
+        }
+
+        .edit-metadata-grid .form-group {
+            grid-column: 1 / -1;
+        }
+
+        .edit-metadata-grid .form-group.half {
+            grid-column: span 1;
+        }
+
+        .artwork-preview {
+            width: 96px;
+            height: 96px;
+            border: 2px dashed var(--glass-border);
+            border-radius: 8px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            overflow: hidden;
+            cursor: pointer;
+            flex-shrink: 0;
+            transition: border-color 0.2s;
+        }
+
+        .artwork-preview:hover {
+            border-color: var(--accent-orange);
+        }
+
+        .artwork-preview img {
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+        }
+
+        .artwork-placeholder {
+            color: var(--text-mid);
+            font-size: 11px;
+            text-align: center;
+            line-height: 1.4;
+            pointer-events: none;
+        }
+
         /* Progress bar */
         .progress-bar {
             width: 100%;
@@ -973,6 +1041,66 @@
         </div>
     </div>
 
+    <!-- Edit Metadata Modal -->
+    <div class="modal-overlay" id="editMetadataModal">
+        <div class="modal" style="max-width: 480px;">
+            <h2 id="editModalTitle">Edit Track</h2>
+            <div class="edit-metadata-grid">
+                <div class="form-group">
+                    <label for="editTitle">Title</label>
+                    <input type="text" id="editTitle" data-placeholder="Title" placeholder="Title">
+                </div>
+                <div class="form-group">
+                    <label for="editArtist">Artist</label>
+                    <input type="text" id="editArtist" data-placeholder="Artist" placeholder="Artist">
+                </div>
+                <div class="form-group">
+                    <label for="editAlbum">Album</label>
+                    <input type="text" id="editAlbum" data-placeholder="Album" placeholder="Album">
+                </div>
+                <div class="form-group">
+                    <label for="editGenre">Genre</label>
+                    <input type="text" id="editGenre" data-placeholder="Genre" placeholder="Genre">
+                </div>
+                <div class="form-group half">
+                    <label for="editTrackNr">Track #</label>
+                    <input type="number" id="editTrackNr" data-placeholder="Track #" placeholder="Track #" min="0" max="999">
+                </div>
+                <div class="form-group half">
+                    <label for="editYear">Year</label>
+                    <input type="number" id="editYear" data-placeholder="Year" placeholder="Year" min="1900" max="2099">
+                </div>
+                <div class="form-group">
+                    <label for="editRating">Rating</label>
+                    <select id="editRating">
+                        <option value="">— No change —</option>
+                        <option value="0">☆☆☆☆☆ (0 stars)</option>
+                        <option value="20">★☆☆☆☆ (1 star)</option>
+                        <option value="40">★★☆☆☆ (2 stars)</option>
+                        <option value="60">★★★☆☆ (3 stars)</option>
+                        <option value="80">★★★★☆ (4 stars)</option>
+                        <option value="100">★★★★★ (5 stars)</option>
+                    </select>
+                </div>
+                <div class="form-group">
+                    <label>Album Art</label>
+                    <div style="display: flex; align-items: flex-start; gap: 10px;">
+                        <div class="artwork-preview" id="artworkPreview" title="Click to choose artwork">
+                            <span class="artwork-placeholder">Click to<br>set artwork</span>
+                        </div>
+                        <button type="button" class="btn btn-secondary" id="artworkClearBtn"
+                                style="display: none; font-size: 11px; padding: 4px 8px;">✕ Clear</button>
+                    </div>
+                    <input type="file" id="artworkFileInput" accept="image/*" style="display: none;">
+                </div>
+            </div>
+            <div class="modal-actions">
+                <button class="btn btn-secondary" onclick="hideEditTrackModal()">Cancel</button>
+                <button class="btn btn-primary" onclick="saveTrackEdits()">Save</button>
+            </div>
+        </div>
+    </div>
+
     <!-- Context Menu -->
     <div class="context-menu" id="contextMenu">
         <div class="context-menu-item" id="contextDeletePlaylist" style="display: none;">
@@ -980,6 +1108,9 @@
         </div>
         <div class="context-menu-item" id="contextDeleteTrack" style="display: none;">
             Delete Track
+        </div>
+        <div class="context-menu-item" id="contextEditTrack" style="display: none;">
+            Edit Metadata
         </div>
         <div class="context-menu-item context-submenu" id="contextAddToPlaylist" style="display: none;">
             Add to Playlist

--- a/modules/contextMenu.js
+++ b/modules/contextMenu.js
@@ -4,7 +4,8 @@ export function createContextMenu({
     getCurrentPlaylistIndex,
     getSelectedTrackIds,
     ensureTrackSelected,
-    actions
+    actions,
+    onEditTracks,
 }) {
     const state = { type: null, playlistIndex: null, trackIds: [] };
 
@@ -74,6 +75,7 @@ export function createContextMenu({
 
         const deletePlaylistBtn = document.getElementById('contextDeletePlaylist');
         const deleteTrackBtn = document.getElementById('contextDeleteTrack');
+        const editTrackBtn = document.getElementById('contextEditTrack');
         const addToPlaylistBtn = document.getElementById('contextAddToPlaylist');
         const removeFromPlaylistBtn = document.getElementById('contextRemoveFromPlaylist');
 
@@ -99,6 +101,13 @@ export function createContextMenu({
                         await actions?.deleteTrack?.(tid);
                     }
                 }
+                hideContextMenu();
+            }
+        });
+
+        editTrackBtn?.addEventListener('click', () => {
+            if (state.type === 'track' && state.trackIds?.length) {
+                onEditTracks?.(state.trackIds);
                 hideContextMenu();
             }
         });
@@ -152,6 +161,7 @@ export function createContextMenu({
 
             const deletePlaylistBtn = document.getElementById('contextDeletePlaylist');
             const deleteTrackBtn = document.getElementById('contextDeleteTrack');
+            const editTrackBtn = document.getElementById('contextEditTrack');
             const addToPlaylistBtn = document.getElementById('contextAddToPlaylist');
             const removeFromPlaylistBtn = document.getElementById('contextRemoveFromPlaylist');
             if (!deletePlaylistBtn || !deleteTrackBtn || !addToPlaylistBtn || !removeFromPlaylistBtn) return;
@@ -162,6 +172,7 @@ export function createContextMenu({
 
             deletePlaylistBtn.style.display = 'block';
             deleteTrackBtn.style.display = 'none';
+            if (editTrackBtn) editTrackBtn.style.display = 'none';
             addToPlaylistBtn.style.display = 'none';
             removeFromPlaylistBtn.style.display = 'none';
 
@@ -189,6 +200,7 @@ export function createContextMenu({
 
             const deletePlaylistBtn = document.getElementById('contextDeletePlaylist');
             const deleteTrackBtn = document.getElementById('contextDeleteTrack');
+            const editTrackBtn = document.getElementById('contextEditTrack');
             const addToPlaylistBtn = document.getElementById('contextAddToPlaylist');
             const removeFromPlaylistBtn = document.getElementById('contextRemoveFromPlaylist');
             if (!deletePlaylistBtn || !deleteTrackBtn || !addToPlaylistBtn || !removeFromPlaylistBtn) return;
@@ -205,10 +217,12 @@ export function createContextMenu({
 
             deletePlaylistBtn.style.display = 'none';
             deleteTrackBtn.style.display = 'block';
+            if (editTrackBtn) editTrackBtn.style.display = 'block';
             addToPlaylistBtn.style.display = 'block';
 
             // Update labels for multi-select
             deleteTrackBtn.textContent = trackIds.length > 1 ? `Delete ${trackIds.length} Tracks` : 'Delete Track';
+            if (editTrackBtn) editTrackBtn.textContent = trackIds.length > 1 ? `Edit ${trackIds.length} Tracks` : 'Edit Metadata';
 
             buildPlaylistSubmenu(trackIds);
 

--- a/modules/metadataEditor.js
+++ b/modules/metadataEditor.js
@@ -1,0 +1,265 @@
+export function createMetadataEditor({ wasm, log, refreshCurrentView }) {
+    let editingTrackIds = [];
+
+    // ── artwork state ────────────────────────────────────────────────────────
+    // Holds the pre-decoded RGBA artwork the user picked via the file dialog.
+    // Cleared every time the modal opens or the user clicks the × button.
+    let pendingArtwork = null;   // { rgba: Uint8Array, width: number, height: number } | null
+
+    const ARTWORK_MAX_SIZE = 320; // iPod Classic max artwork dimension
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    function getSharedField(trackData, field) {
+        const values = [...new Set(trackData.map(t => String(t[field] ?? '')))];
+        return values.length === 1 ? values[0] : null; // null = multiple values
+    }
+
+    function setInputField(inputId, value, batchPlaceholder = 'Multiple values') {
+        const el = document.getElementById(inputId);
+        if (!el) return;
+        if (value !== null) {
+            el.value = value;
+            el.placeholder = el.dataset.placeholder || '';
+        } else {
+            el.value = '';
+            el.placeholder = batchPlaceholder;
+        }
+    }
+
+    function getInputVal(id) {
+        return document.getElementById(id)?.value.trim() ?? '';
+    }
+
+    // ── artwork helpers ──────────────────────────────────────────────────────
+
+    /**
+     * Resize an image file (Blob / File) to at most ARTWORK_MAX_SIZE × ARTWORK_MAX_SIZE
+     * using an off-screen Canvas.  Returns the raw RGBA Uint8Array plus dimensions.
+     */
+    function decodeAndResizeImage(file) {
+        return new Promise((resolve, reject) => {
+            const url = URL.createObjectURL(file);
+            const img = new Image();
+            img.onload = () => {
+                URL.revokeObjectURL(url);
+                let { width, height } = img;
+
+                // Scale down keeping aspect ratio — artwork is always square on iPod
+                // but we preserve the original ratio so libgpod can crop/pad as needed.
+                const scale = Math.min(1, ARTWORK_MAX_SIZE / Math.max(width, height));
+                width  = Math.round(width  * scale);
+                height = Math.round(height * scale);
+
+                const canvas = document.createElement('canvas');
+                canvas.width  = width;
+                canvas.height = height;
+                const ctx = canvas.getContext('2d');
+                ctx.drawImage(img, 0, 0, width, height);
+
+                const imageData = ctx.getImageData(0, 0, width, height);
+                resolve({
+                    rgba:   new Uint8Array(imageData.data.buffer),
+                    width,
+                    height,
+                });
+            };
+            img.onerror = () => {
+                URL.revokeObjectURL(url);
+                reject(new Error('Failed to decode image'));
+            };
+            img.src = url;
+        });
+    }
+
+    /** Show a thumbnail preview inside the artwork-preview container. */
+    function showArtworkPreview(file) {
+        const preview = document.getElementById('artworkPreview');
+        if (!preview) return;
+        const url = URL.createObjectURL(file);
+        preview.innerHTML = `<img src="${url}" alt="Artwork preview">`;
+        // Show the clear button
+        const clearBtn = document.getElementById('artworkClearBtn');
+        if (clearBtn) clearBtn.style.display = 'inline-block';
+    }
+
+    /** Reset artwork preview to the placeholder state. */
+    function clearArtworkPreview() {
+        const preview = document.getElementById('artworkPreview');
+        if (preview) {
+            preview.innerHTML = '<span class="artwork-placeholder">Click to<br>set artwork</span>';
+        }
+        const clearBtn = document.getElementById('artworkClearBtn');
+        if (clearBtn) clearBtn.style.display = 'none';
+    }
+
+    /** Wire up the hidden file input + artwork preview click. */
+    function initArtworkInput() {
+        const preview = document.getElementById('artworkPreview');
+        const fileInput = document.getElementById('artworkFileInput');
+        if (!preview || !fileInput) return;
+
+        preview.addEventListener('click', () => fileInput.click());
+
+        fileInput.addEventListener('change', async () => {
+            const file = fileInput.files?.[0];
+            if (!file) return;
+            try {
+                pendingArtwork = await decodeAndResizeImage(file);
+                showArtworkPreview(file);
+                log?.(`Artwork loaded: ${pendingArtwork.width}×${pendingArtwork.height}`, 'info');
+            } catch (e) {
+                log?.(`Failed to process artwork: ${e.message}`, 'error');
+                pendingArtwork = null;
+                clearArtworkPreview();
+            }
+            // Reset so selecting the same file again triggers change
+            fileInput.value = '';
+        });
+
+        const clearBtn = document.getElementById('artworkClearBtn');
+        if (clearBtn) {
+            clearBtn.addEventListener('click', (e) => {
+                e.stopPropagation();
+                clearArtworkSelection();
+            });
+        }
+    }
+
+    function clearArtworkSelection() {
+        pendingArtwork = null;
+        clearArtworkPreview();
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    function showEditModal(trackIds) {
+        editingTrackIds = (Array.isArray(trackIds) ? trackIds : [trackIds])
+            .filter(id => Number.isFinite(id));
+        if (editingTrackIds.length === 0) return;
+
+        const trackData = editingTrackIds
+            .map(id => wasm.wasmGetJson('ipod_get_track_json', id))
+            .filter(Boolean);
+        if (trackData.length === 0) return;
+
+        const isBatch = editingTrackIds.length > 1;
+
+        // String fields
+        setInputField('editTitle',  isBatch ? null : getSharedField(trackData, 'title'));
+        setInputField('editArtist', getSharedField(trackData, 'artist'));
+        setInputField('editAlbum',  getSharedField(trackData, 'album'));
+        setInputField('editGenre',  getSharedField(trackData, 'genre'));
+
+        // Number fields — treat 0 as "not set" so the input appears empty.
+        const trackNrVal = getSharedField(trackData, 'track_nr');
+        setInputField('editTrackNr', trackNrVal !== '0' ? trackNrVal : '');
+
+        const yearVal = getSharedField(trackData, 'year');
+        setInputField('editYear', yearVal !== '0' ? yearVal : '');
+
+        // Rating select
+        const ratingEl = document.getElementById('editRating');
+        if (ratingEl) {
+            const ratingVal = getSharedField(trackData, 'rating');
+            ratingEl.value = ratingVal !== null ? ratingVal : '';
+        }
+
+        // Modal title
+        const titleEl = document.getElementById('editModalTitle');
+        if (titleEl) titleEl.textContent = isBatch ? `Edit ${editingTrackIds.length} Tracks` : 'Edit Track';
+
+        // Reset artwork state for every open
+        clearArtworkSelection();
+
+        document.getElementById('editMetadataModal')?.classList.add('show');
+        setTimeout(() => document.getElementById('editTitle')?.focus(), 50);
+    }
+
+    function hideEditModal() {
+        document.getElementById('editMetadataModal')?.classList.remove('show');
+        editingTrackIds = [];
+        pendingArtwork = null;
+    }
+
+    function saveTrackEdits() {
+        if (editingTrackIds.length === 0) return;
+
+        const title  = getInputVal('editTitle')  || null;
+        const artist = getInputVal('editArtist') || null;
+        const album  = getInputVal('editAlbum')  || null;
+        const genre  = getInputVal('editGenre')  || null;
+
+        const trackNrStr = getInputVal('editTrackNr');
+        const yearStr    = getInputVal('editYear');
+        const ratingStr  = getInputVal('editRating');
+
+        const trackNr = trackNrStr !== '' ? parseInt(trackNrStr, 10) : -1;
+        const year    = yearStr    !== '' ? parseInt(yearStr,    10) : -1;
+        const rating  = ratingStr  !== '' ? parseInt(ratingStr,  10) : -1;
+
+        const hasMetadataChanges = title || artist || album || genre || trackNr >= 0 || year > 0 || rating >= 0;
+        const hasArtwork = pendingArtwork !== null;
+
+        if (!hasMetadataChanges && !hasArtwork) {
+            log?.('No changes to save', 'warning');
+            return;
+        }
+
+        let metaSuccess = 0;
+        let artSuccess  = 0;
+
+        for (const trackId of editingTrackIds) {
+            // ─ metadata ─
+            if (hasMetadataChanges) {
+                const result = wasm.wasmUpdateTrack(trackId, { title, artist, album, genre, trackNr, year, rating });
+                if (result === 0) {
+                    metaSuccess++;
+                } else {
+                    log?.(`Failed to update metadata for track ${trackId}`, 'error');
+                }
+            }
+
+            // ─ artwork ─
+            if (hasArtwork) {
+                const { rgba, width, height } = pendingArtwork;
+                const result = wasm.wasmSetTrackArtworkRGBA(trackId, rgba, width, height);
+                if (result === 0) {
+                    artSuccess++;
+                } else if (result === -2) {
+                    // GdkPixbuf not available — stop trying for remaining tracks
+                    log?.('Artwork requires a rebuilt WASM with GdkPixbuf support. See build.sh.', 'error');
+                    break;
+                } else {
+                    log?.(`Failed to set artwork for track ${trackId}`, 'error');
+                }
+            }
+        }
+
+        // ─ summary ─
+        const parts = [];
+        if (metaSuccess > 0)
+            parts.push(`metadata for ${metaSuccess} ${metaSuccess === 1 ? 'track' : 'tracks'}`);
+        if (artSuccess > 0)
+            parts.push(`artwork for ${artSuccess} ${artSuccess === 1 ? 'track' : 'tracks'}`);
+
+        if (parts.length > 0) {
+            log?.(`Updated ${parts.join(' and ')}. Click "Sync iPod" to save to device.`, 'success');
+            refreshCurrentView();
+        }
+
+        if (metaSuccess === 0 && artSuccess === 0) {
+            log?.('All updates failed. Check the console log for details.', 'error');
+            return;
+        }
+
+        hideEditModal();
+    }
+
+    // One-time DOM wiring (called after DOM is ready)
+    function init() {
+        initArtworkInput();
+    }
+
+    return { showEditModal, hideEditModal, saveTrackEdits, clearArtworkSelection, init };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -488,325 +488,350 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
-      "integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
-      "integrity": "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz",
-      "integrity": "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
+      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
-      "integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
-      "integrity": "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
-      "integrity": "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
-      "integrity": "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
-      "integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
-      "integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
-      "integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
-      "integrity": "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
       "cpu": [
         "loong64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
-      "integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
       "cpu": [
         "loong64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
-      "integrity": "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
-      "integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
-      "integrity": "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
-      "integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
-      "integrity": "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
-      "integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
-      "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
+      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
-      "integrity": "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
-      "integrity": "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "openharmony"
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
-      "integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
-      "integrity": "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
       "cpu": [
         "ia32"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
-      "integrity": "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
-      "integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -1043,6 +1068,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1079,10 +1105,11 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
-      "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
+      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -1094,31 +1121,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.57.1",
-        "@rollup/rollup-android-arm64": "4.57.1",
-        "@rollup/rollup-darwin-arm64": "4.57.1",
-        "@rollup/rollup-darwin-x64": "4.57.1",
-        "@rollup/rollup-freebsd-arm64": "4.57.1",
-        "@rollup/rollup-freebsd-x64": "4.57.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.57.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.57.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.57.1",
-        "@rollup/rollup-linux-arm64-musl": "4.57.1",
-        "@rollup/rollup-linux-loong64-gnu": "4.57.1",
-        "@rollup/rollup-linux-loong64-musl": "4.57.1",
-        "@rollup/rollup-linux-ppc64-gnu": "4.57.1",
-        "@rollup/rollup-linux-ppc64-musl": "4.57.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.57.1",
-        "@rollup/rollup-linux-riscv64-musl": "4.57.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.57.1",
-        "@rollup/rollup-linux-x64-gnu": "4.57.1",
-        "@rollup/rollup-linux-x64-musl": "4.57.1",
-        "@rollup/rollup-openbsd-x64": "4.57.1",
-        "@rollup/rollup-openharmony-arm64": "4.57.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.57.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.57.1",
-        "@rollup/rollup-win32-x64-gnu": "4.57.1",
-        "@rollup/rollup-win32-x64-msvc": "4.57.1",
+        "@rollup/rollup-android-arm-eabi": "4.59.0",
+        "@rollup/rollup-android-arm64": "4.59.0",
+        "@rollup/rollup-darwin-arm64": "4.59.0",
+        "@rollup/rollup-darwin-x64": "4.59.0",
+        "@rollup/rollup-freebsd-arm64": "4.59.0",
+        "@rollup/rollup-freebsd-x64": "4.59.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
+        "@rollup/rollup-linux-arm64-musl": "4.59.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
+        "@rollup/rollup-linux-loong64-musl": "4.59.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-musl": "4.59.0",
+        "@rollup/rollup-openbsd-x64": "4.59.0",
+        "@rollup/rollup-openharmony-arm64": "4.59.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
+        "@rollup/rollup-win32-x64-gnu": "4.59.0",
+        "@rollup/rollup-win32-x64-msvc": "4.59.0",
         "fsevents": "~2.3.2"
       }
     },


### PR DESCRIPTION
## Summary

Add a metadata editor modal that lets users edit track metadata (title, artist, album, genre, track #, year, rating) and set album artwork — all from the browser.

### What works now (no rebuild needed)

- **Metadata editing**: single-track and batch editing via right-click > "Edit Metadata" or double-click a track row
- **Keyboard shortcuts**: Enter to save, Escape to close
- **Artwork UI**: file picker with Canvas-based decode/resize to 320x320 RGBA + preview thumbnail

### What needs a WASM rebuild (artwork saving)

The artwork pipeline decodes images in JS via Canvas and passes raw RGBA pixels to a new C function `ipod_track_set_artwork_from_rgba()`. This function wraps the pixels in a `GdkPixbuf` (using `gdk_pixbuf_new_from_data()` — no image loaders needed) and hands it to `itdb_track_set_thumbnails_from_pixbuf()`.

Until the WASM is rebuilt, saving artwork shows: *"Artwork requires a rebuilt WASM with GdkPixbuf support."*

### Build steps required (@rish1p)

#### 1. Install gdk-pixbuf in the conda environment

```bash
micromamba install -n libgpod-wasm-latest gdk-pixbuf \
  -c emscripten-forge -c conda-forge --platform=emscripten-wasm32
```

Verify:
```bash
ls $MAMBA_ENV/lib/libgdk_pixbuf-2.0.a
ls $MAMBA_ENV/include/gdk-pixbuf-2.0/
```

#### 2. Ensure libgpod was compiled with GdkPixbuf support

If not already, re-configure libgpod with `--enable-gdkpixbuf` (or equivalent) so `itdb_track_set_thumbnails_from_pixbuf()` is compiled in, then rebuild.

#### 3. Apply these 4 changes to build.sh and rebuild

**a) Add include path** (in INCLUDE_PATHS):
```bash
"-I${MAMBA_ENV}/include/gdk-pixbuf-2.0"
```

**b) Add library** (in LIBS, after libplist):
```bash
"${MAMBA_ENV}/lib/libgdk_pixbuf-2.0.a"
```

**c) Add compile flag** (in CFLAGS):
```bash
"-DHAVE_GDKPIXBUF"
```

**d) Add export** (in EXPORTED_FUNCTIONS, after _ipod_track_set_artwork_from_data):
```
'_ipod_track_set_artwork_from_rgba'
```

Then run `./build.sh` and commit the updated `public/ipod_manager.js` + `public/ipod_manager.wasm`.

### Files changed

| File | Change |
|------|--------|
| `modules/metadataEditor.js` | **New** — metadata editor + artwork pipeline |
| `ipod_manager.c` | New `ipod_track_set_artwork_from_rgba()` (guarded by `#ifdef HAVE_GDKPIXBUF`) |
| `modules/wasmApi.js` | New `wasmSetTrackArtworkRGBA()` wrapper |
| `modules/contextMenu.js` | Wire "Edit Metadata" to `onEditTracks` callback |
| `main.js` | Initialize editor, expose modal functions, add dblclick handler |
| `index.html` | Add edit modal HTML + artwork picker UI + CSS |
